### PR TITLE
ssh: support using ssh-configured user

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -44,7 +44,7 @@ let {
 
     mkTarget = s: let
       default = defVal: val: if val != null then val else defVal;
-      parse = lib.match "(([^@]+)@)?(([^:/]+))?(:([^/]+))?(/.*)?" s;
+      parse = lib.match "(([^@]*)@)?(([^:/]+))?(:([^/]+))?(/.*)?" s;
       elemAt' = xs: i: if lib.length xs > i then lib.elemAt xs i else null;
     in {
       user = default (lib.getEnv "LOGNAME") (elemAt' parse 1);

--- a/pkgs/krops/default.nix
+++ b/pkgs/krops/default.nix
@@ -20,9 +20,9 @@ in
   remoteCommand = target: command:
     exec "build.${target.host}" rec {
       filename = "${openssh}/bin/ssh";
-      argv = [
+      argv = lib.flatten [
         filename
-        "-l" target.user
+        (lib.optionals (target.user != "") ["-l" target.user])
         "-p" target.port
         "-t"
         target.host

--- a/pkgs/populate/default.nix
+++ b/pkgs/populate/default.nix
@@ -162,8 +162,10 @@ let
         --delete-excluded \
         "$source_path" \
         ${quote (
-          optionalString (!isLocalTarget target)
-                         "${target.user}@${target.host}:" +
+          optionalString (!isLocalTarget target) (
+            (optionalString (target.user != "") "${target.user}@") +
+            "${target.host}:"
+          ) +
           target.path
         )} \
       >&2
@@ -176,13 +178,13 @@ let
         ${ssh' target} ${quote target.host} ${quote script}
       '';
 
-  ssh' = target: concatMapStringsSep " " quote [
+  ssh' = target: concatMapStringsSep " " quote (flatten [
     "${openssh}/bin/ssh"
-    "-l" target.user
+    (optionals (target.user != "") ["-l" target.user])
     "-o" "ControlPersist=no"
     "-p" target.port
     "-T"
-  ];
+  ]);
 
 in
 


### PR DESCRIPTION
Let ssh use the user configured in its configuration files when the target user is set to the empty string.

Closes https://github.com/krebs/krops/issues/2