### PR TITLE
populate: re-add default values for useChecksum/exclude

### DIFF
--- a/pkgs/populate/default.nix
+++ b/pkgs/populate/default.nix
@@ -156,11 +156,11 @@ let
       source_path=$source_path/
     fi
     ${rsync}/bin/rsync \
-        ${optionalString config.useChecksum /* sh */ "--checksum"} \
+        ${optionalString (config.useChecksum or false) /* sh */ "--checksum"} \
         ${optionalString target.sudo /* sh */ "--rsync-path=\"sudo rsync\""} \
         ${concatMapStringsSep " "
           (pattern: /* sh */ "--exclude ${quote pattern}")
-          config.exclude} \
+          (config.exclude or [])} \
         -e ${quote (ssh' target)} \
         -vFrlptD \
         --delete-excluded \


### PR DESCRIPTION
Turns out, those where required.