### PR TITLE
use writers from nixpkgs

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1,15 +1,7 @@
 { overlays ? [], ... }@args:
 
-let
-  nix-writers = builtins.fetchGit {
-    url = https://cgit.krebsco.de/nix-writers/;
-    rev = "c528cf970e292790b414b4c1c8c8e9d7e73b2a71";
-  };
-in
-
 import <nixpkgs> (args // {
   overlays = [
     (import ./overlay.nix)
-    (import "${nix-writers}/pkgs")
   ] ++ overlays;
 })

--- a/pkgs/populate/default.nix
+++ b/pkgs/populate/default.nix
@@ -1,7 +1,7 @@
 with import ../../lib;
 with shell;
 
-{ coreutils, dash, findutils, git, jq, openssh, pass, rsync, writeDash }:
+{ coreutils, dash, findutils, git, jq, openssh, pass, rsync, writers }:
 
 let
   check = { force, target }: let
@@ -145,7 +145,7 @@ let
   populate = target: name: source: let
     source' = source.${source.type};
     target' = target // { path = "${target.path}/${name}"; };
-  in writeDash "populate.${target'.host}.${name}" ''
+  in writers.writeDash "populate.${target'.host}.${name}" ''
     set -efu
     ${pop.${source.type} target' source'}
   '';
@@ -196,7 +196,7 @@ let
 in
 
 { backup ? false, force ? false, source, target }:
-writeDash "populate.${target.host}" ''
+writers.writeDash "populate.${target.host}" ''
   set -efu
   ${check { inherit force target; }}
   set -x


### PR DESCRIPTION
This makes the evaluation of krops pure (no import from derivation)
and makes it faster since the fetchGit result might be garbage collected.