### PR TITLE
Improve deploy target options

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -52,6 +52,7 @@ let {
       port = default "22" /* "ssh"? */ (elemAt' parse 5);
       path = default "/var/src" /* no default? */ (elemAt' parse 6);
       sudo = false;
+      extraOptions = [];
     } else s;
 
     shell = let

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -43,17 +43,22 @@ let {
       lib.elem target.host [origin.host "localhost"];
 
     mkTarget = s: let
-      default = defVal: val: if val != null then val else defVal;
       parse = lib.match "(([^@]*)@)?(([^:/]+))?(:([^/]+))?(/.*)?" s;
       elemAt' = xs: i: if lib.length xs > i then lib.elemAt xs i else null;
-    in if lib.isString s then {
-      user = default (lib.getEnv "LOGNAME") (elemAt' parse 1);
-      host = default (lib.maybeEnv "HOSTNAME" lib.getHostName) (elemAt' parse 3);
-      port = default "22" /* "ssh"? */ (elemAt' parse 5);
-      path = default "/var/src" /* no default? */ (elemAt' parse 6);
+      filterNull = lib.filterAttrs (n: v: v != null);
+    in {
+      user = lib.getEnv "LOGNAME";
+      host = lib.maybeEnv "HOSTNAME" lib.getHostName;
+      port = "22";
+      path = "/var/src";
       sudo = false;
       extraOptions = [];
-    } else s;
+    } // (if lib.isString s then filterNull {
+      user = elemAt' parse 1;
+      host = elemAt' parse 3;
+      port = elemAt' parse 5;
+      path = elemAt' parse 6;
+    } else s);
 
     shell = let
       isSafeChar = lib.testString "[-+./0-9:=A-Z_a-z]";

--- a/pkgs/krops/default.nix
+++ b/pkgs/krops/default.nix
@@ -23,6 +23,7 @@ in
         (lib.optionals (target.user != "") ["-l" target.user])
         "-p" target.port
         "-t"
+        target.extraOptions
         target.host
         (if target.sudo then "sudo ${command}" else command)])}
     '';

--- a/pkgs/populate/default.nix
+++ b/pkgs/populate/default.nix
@@ -194,6 +194,7 @@ let
     "-o" "ControlPersist=no"
     "-p" target.port
     "-T"
+    target.extraOptions
   ]);
 
 in


### PR DESCRIPTION
Rationale for `add target.extraOptions`:
I'd like to use krops for unattended local deployments that don't write to the local `$HOME/.ssh` config. This is only possible with custom SSH options (or via bind-mounting $HOME).

Edit: This fixes #6.