### PR TITLE
add shallow option to git source type

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,10 @@ Supported attributes:
 * `clean.exclude` -
   List of patterns that should be excluded from Git cleaning.
 
+* `shallow` (optional)
+  boolean that controls whether only the requested commit ref. should be fetched
+  instead of the whole history, to save disk space and bandwith. Defaults to `false`.
+
 
 ### `pass`
 

--- a/lib/types/populate.nix
+++ b/lib/types/populate.nix
@@ -140,6 +140,10 @@
         url = lib.mkOption {
           type = lib.types.str; # TODO lib.types.git.url
         };
+        shallow = lib.mkOption {
+          default = false;
+          type = lib.types.bool;
+        };
       };
     };
     pass = lib.types.submodule {


### PR DESCRIPTION
# Motivation
For most of our deployments only a specific revision is needed when using the git source type, not the full history.

# Things changed
This introduces the `shallow` option to the git source type, which uses --depth=1 to fetch only a specific revision.

This saves disk space, time and bandwith - e.g. when cloning a big repo like nixpkgs.