### PR TITLE
Add flag to nixos-rebuild

### DIFF
--- a/pkgs/krops/default.nix
+++ b/pkgs/krops/default.nix
@@ -80,6 +80,8 @@ in
       ] ++ lib.optionals (buildTarget' != target') [
         "--build-host" "${buildTarget'.user}@${buildTarget'.host}"
         "--target-host" "${target'.user}@${target'.host}"
+      ] ++ lib.optionals target'.sudo [
+        "--use-remote-sudo"
       ]) buildTarget'}
     '';
 


### PR DESCRIPTION
In the case we need sudo for the remote target, the flag
`--use-remote-sudo` must be passed if the target's ssh user is not root.

If target's ssh user is root, it doesn't hurt to use sudo.