### PR TITLE
Make pass source follow symlinks

### DIFF
--- a/pkgs/populate/default.nix
+++ b/pkgs/populate/default.nix
@@ -119,7 +119,7 @@ let
       rm -fR "$tmp_dir"
     }
 
-    ${findutils}/bin/find ${quote passPrefix} -type f |
+    ${findutils}/bin/find ${quote passPrefix} -type f -follow |
     while read -r gpg_path; do
 
       rel_name=''${gpg_path#${quote passPrefix}}


### PR DESCRIPTION
Since my hosts share some secrets, I use symlinks inside my password-store. Currently, krops does not copy the secrets that are linked, since `find -type f` ignores them.

This PR adds the `-follow` option to `find` to also include symlinked secrets.