### PR TITLE
target: use default port from SSH config

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Create a file named `krops.nix` (name doesn't matter) with following content:
 let
   krops = (import <nixpkgs> {}).fetchgit {
     url = https://cgit.krebsco.de/krops/;
-    rev = "v1.17.0";
-    sha256 = "150jlz0hlb3ngf9a1c9xgcwzz1zz8v2lfgnzw08l3ajlaaai8smd";
+    rev = "v1.25.0";
+    sha256 = "07mg3iaqjf1w49vmwfchi7b1w55bh7rvsbgicp2m47gnj9alwdb6";
   };
 
   lib = import "${krops}/lib";

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ krops is a lightweight toolkit to deploy NixOS systems, remotely or locally.
 ## Some Features
 
 - store your secrets in [password store](https://www.passwordstore.org/)
-- build your system remotely
+- build your systems remotely
 - minimal overhead (it's basically just `nixos-rebuild switch`!)
 - run from custom nixpkgs branch/checkout/fork
 

--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ Supported attributes:
   whether a file has changed.  This is useful when `path` points at files
   with mangled timestamps, e.g. the Nix store.
 
+  The default value is `true` if `path` is a derivation, and `false` otherwise.
+
 * `filters` (optional)
   List of filters that should be passed to [`rsync`](https://rsync.samba.org/).
   Filters are specified as attribute sets with the attributes `type` and

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ using [`rsync`](https://rsync.samba.org/).
 Supported attributes:
 
 * `path` -
-  absolute path to files that should by transfered
+  absolute path to files that should by transferred.
 
 * `useChecksum` (optional) -
   boolean that controls whether file contents should be checked to decide

--- a/README.md
+++ b/README.md
@@ -185,6 +185,10 @@ pkgs.krops.writeCommand "deploy-with-swap" {
 
 [see `writeDeploy`](#writeDeploy)
 
+### `allocateTTY` (optional, defaults to false)
+
+whether the ssh session should do a pseudo-terminal allocation.
+sets `-t` on the ssh command.
 
 ## Source Types
 

--- a/ci.nix
+++ b/ci.nix
@@ -5,7 +5,7 @@ let
   pkgs = import "${krops}/pkgs" {};
 
   source = lib.evalSource [{
-    nixos-config.file = toString (pkgs.writeText "nixos-config" ''
+    nixos-config.file = pkgs.writeText "nixos-config" ''
       { pkgs, ... }: {
 
         fileSystems."/" = { device = "/dev/sda1"; };
@@ -13,7 +13,7 @@ let
         services.openssh.enable = true;
         environment.systemPackages = [ pkgs.git ];
       }
-    '');
+    '';
     nixpkgs.symlink = toString <nixpkgs>;
   }];
 in {

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -57,9 +57,9 @@ let {
       elemAt' = xs: i: if lib.length xs > i then lib.elemAt xs i else null;
       filterNull = lib.filterAttrs (n: v: v != null);
     in {
-      user = lib.getEnv "LOGNAME";
+      user = lib.maybeEnv "LOGNAME" null;
       host = lib.maybeEnv "HOSTNAME" (lib.maybeHostName "localhost");
-      port = "22";
+      port = null;
       path = "/var/src";
       sudo = false;
       extraOptions = [];
@@ -69,6 +69,10 @@ let {
       port = elemAt' parse 5;
       path = elemAt' parse 6;
     } else s);
+
+    mkUserPortSSHOpts = target:
+      (lib.optionals (target.user != null) ["-l" target.user]) ++
+      (lib.optionals (target.port != null) ["-p" target.port]);
 
     shell = let
       isSafeChar = lib.testString "[-+./0-9:=A-Z_a-z]";

--- a/lib/types/populate.nix
+++ b/lib/types/populate.nix
@@ -21,11 +21,15 @@
       };
       file = lib.mkOption {
         apply = x:
-          if lib.types.absolute-pathname.check x
+          if lib.types.absolute-pathname.check x || lib.types.package.check x
             then { path = x; }
             else x;
         default = null;
-        type = lib.types.nullOr (lib.types.either lib.types.absolute-pathname source-types.file);
+        type = lib.types.nullOr (lib.types.oneOf [
+          lib.types.absolute-pathname
+          lib.types.package
+          source-types.file
+        ]);
       };
       git = lib.mkOption {
         default = null;

--- a/pkgs/krops/default.nix
+++ b/pkgs/krops/default.nix
@@ -20,8 +20,7 @@ in
       else
         writers.writeDash "krops.${target.host}.${lib.firstWord command}" ''
           exec ${openssh}/bin/ssh ${lib.escapeShellArgs (lib.flatten [
-            (lib.optionals (target.user != "") ["-l" target.user])
-            "-p" target.port
+            (lib.mkUserPortSSHOpts target)
             (if allocateTTY then "-t" else "-T")
             target.extraOptions
             target.host

--- a/pkgs/populate/default.nix
+++ b/pkgs/populate/default.nix
@@ -48,14 +48,14 @@ let
     config = rsyncDefaultConfig // derivedConfig // sourceConfig;
     derivedConfig = {
       useChecksum =
-        if isDerivation source.path
+        if isStorePath source.path
           then true
           else rsyncDefaultConfig.useChecksum;
     };
     sourceConfig =
       filterAttrs (name: _: elem name (attrNames rsyncDefaultConfig)) source;
     sourcePath =
-      if isDerivation source.path
+      if isStorePath source.path
         then quote (toString source.path)
         else quote source.path;
   in

--- a/pkgs/populate/default.nix
+++ b/pkgs/populate/default.nix
@@ -224,8 +224,7 @@ let
 
   ssh' = target: concatMapStringsSep " " quote (flatten [
     "${openssh}/bin/ssh"
-    (optionals (target.user != "") ["-l" target.user])
-    "-p" target.port
+    (mkUserPortSSHOpts target)
     "-T"
     target.extraOptions
   ]);


### PR DESCRIPTION
This change only consists of a single commit based on `master` at `cgit.krebsco.de/krops`; this Github repo is out of date.

#### Copy of commit msg
This is the expected behavior.
The SSH config is also implicitly used for other SSH-related settings.

#### Extra rationale
I just spent a bit too much time helping a novice user with deployment issues.
It turned out he had set a nonstandard port in his SSH config and I didn't expect that krops hardcoded the port.