### PR TITLE
Update README.md to fix broken link with infos to the `target` attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ pkgs.krops.writeDeploy "deploy" {
 }
 ```
 For more details about the `target` attribute, please check the `mkTarget`
-function in [lib/default.nix](lib/defaults.nix).
+function in [lib/default.nix](lib/default.nix).
 
 ### `backup` (optional, defaults to false)
 


### PR DESCRIPTION
fix broken link to with infos to the `target` attribute